### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,14 @@ language: php
 
 matrix:
   include:
-    - php: 5.6
-    - php: 7
-      env: LINT=yes QA=yes
-    - php: 7.1
+    - php: 7.2
     - php: nightly
 
 install:
   - composer selfupdate
   - if [ "$LINT" == "yes" ]; then composer global require --update-no-dev sugared-rim/cs; fi
   - composer install
-  - if [ "$QA" == "yes" ]; then composer global require --update-no-dev codeclimate/php-test-reporter:dev-master satooshi/php-coveralls; fi
+  - if [ "$QA" == "yes" ]; then composer global require --update-no-dev codeclimate/php-test-reporter:dev-master satooshi/php-coveralls:^1.0; fi
   - export PATH=$PATH:`composer global config bin-dir --absolute`
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.2",
         "spomky-labs/base64url": "^1.0"
     },
     "require-dev": {

--- a/tests/TokenGeneratorTest.php
+++ b/tests/TokenGeneratorTest.php
@@ -4,13 +4,14 @@ namespace Schnittstabil\Csrf\TokenService;
 
 use InvalidArgumentException;
 use Base64Url\Base64Url;
+use PHPUnit\Framework\TestCase;
 
 /**
  * TokenGenerator Tests.
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
-class TokenGeneratorTest extends \PHPUnit\Framework\TestCase
+class TokenGeneratorTest extends TestCase
 {
     protected $base64url;
     protected $signatory;

--- a/tests/TokenServiceTest.php
+++ b/tests/TokenServiceTest.php
@@ -2,10 +2,12 @@
 
 namespace Schnittstabil\Csrf\TokenService;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * TokenService Tests.
  */
-class TokenServiceTest extends \PHPUnit\Framework\TestCase
+class TokenServiceTest extends TestCase
 {
     public function testValidTokensShouldReturnNoViolations()
     {

--- a/tests/TokenServiceUsageTest.php
+++ b/tests/TokenServiceUsageTest.php
@@ -2,10 +2,12 @@
 
 namespace Schnittstabil\Csrf\TokenService;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * TokenService Usage Tests.
  */
-class TokenServiceUsageTest extends \PHPUnit\Framework\TestCase
+class TokenServiceUsageTest extends TestCase
 {
     /**
      * @runInSeparateProcess

--- a/tests/TokenSignatoryTest.php
+++ b/tests/TokenSignatoryTest.php
@@ -4,11 +4,12 @@ namespace Schnittstabil\Csrf\TokenService;
 
 use InvalidArgumentException;
 use Base64Url\Base64Url;
+use PHPUnit\Framework\TestCase;
 
 /**
  * TokenSignatory Tests.
  */
-class TokenSignatoryTest extends \PHPUnit\Framework\TestCase
+class TokenSignatoryTest extends TestCase
 {
     protected $base64url;
 

--- a/tests/TokenValidatorTest.php
+++ b/tests/TokenValidatorTest.php
@@ -3,11 +3,12 @@
 namespace Schnittstabil\Csrf\TokenService;
 
 use Base64Url\Base64Url;
+use PHPUnit\Framework\TestCase;
 
 /**
  * TokenValidator Tests.
  */
-class TokenValidatorTest extends \PHPUnit\Framework\TestCase
+class TokenValidatorTest extends TestCase
 {
     protected $base64url;
     protected $signatory;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,10 +3,3 @@
 namespace Schnittstabil\Psr7\Csrf;
 
 require __DIR__.'/../vendor/autoload.php';
-
-/*
- * PHPUnit 5/6
- */
-if (!class_exists(\PHPUnit\Framework\TestCase::class)) {
-    class_alias(\PHPUnit_Framework_TestCase::class, \PHPUnit\Framework\TestCase::class);
-}


### PR DESCRIPTION
# Changed log
- Remove the `class_alias` to let the PHPUnit namespace alias in `bootstrap.php` because the PHPUnit version `5+` will use the class-based PHPUnit namespace.
- Set the `satooshi/php-coveralls:^1.0` because `codeclimate/php-test-reporter:dev-master` requires that.